### PR TITLE
library.xbmc.gui version bump ("1.0.0"->"5.0.1")

### DIFF
--- a/addons/library.xbmc.gui/libXBMC_gui.h
+++ b/addons/library.xbmc.gui/libXBMC_gui.h
@@ -36,10 +36,10 @@ typedef void* GUIHANDLE;
 #endif
 
 /* current ADDONGUI API version */
-#define XBMC_GUI_API_VERSION "1.0.0"
+#define XBMC_GUI_API_VERSION "5.0.1"
 
 /* min. ADDONGUI API version */
-#define XBMC_GUI_MIN_API_VERSION "1.0.0"
+#define XBMC_GUI_MIN_API_VERSION "5.0.1"
 
 #define ADDON_ACTION_PREVIOUS_MENU          10
 #define ADDON_ACTION_CLOSE_DIALOG           51

--- a/include/xbmc/libXBMC_gui.h
+++ b/include/xbmc/libXBMC_gui.h
@@ -36,10 +36,10 @@ typedef void* GUIHANDLE;
 #endif
 
 /* current ADDONGUI API version */
-#define XBMC_GUI_API_VERSION "1.0.0"
+#define XBMC_GUI_API_VERSION "5.0.1"
 
 /* min. ADDONGUI API version */
-#define XBMC_GUI_MIN_API_VERSION "1.0.0"
+#define XBMC_GUI_MIN_API_VERSION "5.0.1"
 
 #define ADDON_ACTION_PREVIOUS_MENU          10
 #define ADDON_ACTION_CLOSE_DIALOG           51


### PR DESCRIPTION
Without this patch, running iptvsimple on xbmc-git (c436c99) results in

```
23:23:49 T:139987289831168   ERROR: PVR - Add-on 'PVR IPTV Simple Client' is using an incompatible GUI API version. XBMC minimum GUI API version = '5.0.1', add-on GUI API version '1.0.0'
```
